### PR TITLE
Terraform provider aws upgrade v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ MIT Licensed. See [LICENSE](LICENSE) for full details.
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
-| aws | = 2.70.0 |
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | = 2.70.0 |
+| aws | ~> 3.0 |
 | null | n/a |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ MIT Licensed. See [LICENSE](LICENSE) for full details.
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
-| aws | ~> 2.0 |
+| aws | = 2.70.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | = 2.70.0 |
 | null | n/a |
 
 ## Inputs

--- a/test/vpc_localstack_test.go
+++ b/test/vpc_localstack_test.go
@@ -661,7 +661,7 @@ func ValidateVPCRoute53ZoneName(t *testing.T, terraformOptions *terraform.Option
 	private_subdomain := terraform.Output(t, terraformOptions, "private_subdomain")
 
 	require.Equal(t, terraformOptions.Vars["subdomain"], public_subdomain)
-	require.Equal(t, fmt.Sprintf("%s-net0ps.com.", terraformOptions.Vars["vpc_name"]), private_subdomain)
+	require.Equal(t, fmt.Sprintf("%s-net0ps.com", terraformOptions.Vars["vpc_name"]), private_subdomain)
 }
 
 func ValidateVPCRoutingTables(t *testing.T, terraformOptions *terraform.Options) {

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws = "~> 2.0"
+    aws = "= 2.70.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws = "= 2.70.0"
+    aws = "~> 3.0"
   }
 }


### PR DESCRIPTION
- Upgrade to most recent 2.X version

- Upgrade to version 3.0

- Set required providers aws to ~> 3.0

- Custom variable validation can now be used by default, without enabling an experiment.

- update terraform-docs command

- terraform-docs to README.md

- Fix tests