### PR TITLE
Terraform provider aws upgrade v3 1x

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ MIT Licensed. See [LICENSE](LICENSE) for full details.
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 | null | n/a |
 
 ## Inputs
@@ -35,35 +35,35 @@ MIT Licensed. See [LICENSE](LICENSE) for full details.
 |------|-------------|------|---------|:--------:|
 | azs | Availability zones | `list(string)` | n/a | yes |
 | cidr | CIDR | `string` | n/a | yes |
+| depends_id | For inter module dependencies | `string` | `""` | no |
 | enable | Enable or Disable the module | `bool` | n/a | yes |
+| enable_dns_hostnames | Enable DNS hostnames | `bool` | `true` | no |
+| enable_dns_support | Enable DNS support | `bool` | `true` | no |
 | environment | Environment | `string` | n/a | yes |
-| replication\_factor | Number of subnets, routing tables, NAT gateways | `number` | n/a | yes |
-| vpc\_name | VPC name | `string` | n/a | yes |
-| depends\_id | For inter module dependencies | `string` | `""` | no |
-| enable\_dns\_hostnames | Enable DNS hostnames | `bool` | `true` | no |
-| enable\_dns\_support | Enable DNS support | `bool` | `true` | no |
-| nat\_az\_number | Subnet number to deploy NAT gateway in | `number` | `0` | no |
-| private\_subnet\_tags | n/a | `map(string)` | `{}` | no |
-| public\_subnet\_tags | n/a | `map(string)` | `{}` | no |
+| nat_az_number | Subnet number to deploy NAT gateway in | `number` | `0` | no |
+| private_subnet_tags | n/a | `map(string)` | `{}` | no |
+| public_subnet_tags | n/a | `map(string)` | `{}` | no |
+| replication_factor | Number of subnets, routing tables, NAT gateways | `number` | n/a | yes |
 | subdomain | Subdomain name | `string` | `""` | no |
 | tags | n/a | `map(string)` | `{}` | no |
+| vpc_name | VPC name | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| depends\_id | Dependency ID |
-| net0ps\_zone\_id | Private hosted zone ID |
-| private\_subdomain | Private subdomain name |
-| private\_subnets | Private subnets |
-| private\_zone\_id | Private hosted zone ID |
-| public\_subdomain | Public subdomain name |
-| public\_subdomain\_name\_servers | Public subdomain name servers |
-| public\_subdomain\_zone\_id | Subdomain hosted zone ID |
-| public\_subnets | Public subnets |
-| subdomain\_zone\_id | Subdomain hosted zone ID |
-| vpc\_default\_sg | Default VPC security group |
-| vpc\_id | VPC ID |
-| vpc\_private\_routing\_table\_id | Private routing table ID |
-| vpc\_public\_routing\_table\_id | Public routing table ID |
+| depends_id | Dependency ID |
+| net0ps_zone_id | Private hosted zone ID |
+| private_subdomain | Private subdomain name |
+| private_subnets | Private subnets |
+| private_zone_id | Private hosted zone ID |
+| public_subdomain | Public subdomain name |
+| public_subdomain_name_servers | Public subdomain name servers |
+| public_subdomain_zone_id | Subdomain hosted zone ID |
+| public_subnets | Public subnets |
+| subdomain_zone_id | Subdomain hosted zone ID |
+| vpc_default_sg | Default VPC security group |
+| vpc_id | VPC ID |
+| vpc_private_routing_table_id | Private routing table ID |
+| vpc_public_routing_table_id | Public routing table ID |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - localstack
 
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack:0.11.4
     environment:
       - SERVICES=iam,sts,ec2,route53
       - DEFAULT_REGION=us-east-1

--- a/tests/vpc_localstack_test.go
+++ b/tests/vpc_localstack_test.go
@@ -261,7 +261,7 @@ func ValidateVPCRoute53ZoneName(t *testing.T, terraformOptions *terraform.Option
 	private_subdomain := terraform.Output(t, terraformOptions, "private_subdomain")
 
 	assert.Equal(t, terraformOptions.Vars["subdomain"], public_subdomain)
-	assert.Equal(t, fmt.Sprintf("%s-net0ps.com.", terraformOptions.Vars["vpc_name"]), private_subdomain)
+	assert.Equal(t, fmt.Sprintf("%s-net0ps.com", terraformOptions.Vars["vpc_name"]), private_subdomain)
 }
 
 func ValidateVPCRoutingTables(t *testing.T, terraformOptions *terraform.Options) {

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 2.7"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws = "~> 2.7"
+    aws = "~> 3.0"
   }
 }


### PR DESCRIPTION
Upgrade to most recent 2.X version

Upgrade to version 3.0

Set required providers aws to ~> 3.0

Custom variable validation can now be used by default, without enabling an experiment.

update terraform-docs command

terraform-docs to README.md

Fix tests